### PR TITLE
chore: fix linter warnings

### DIFF
--- a/src/types/address.rs
+++ b/src/types/address.rs
@@ -12,9 +12,9 @@ impl From<TonAddress> for Address {
     }
 }
 
-impl Into<TonAddress> for Address {
-    fn into(self) -> TonAddress {
-        self.0
+impl From<Address> for TonAddress {
+    fn from(value: Address) -> Self {
+        value.0
     }
 }
 

--- a/src/types/coins.rs
+++ b/src/types/coins.rs
@@ -12,9 +12,9 @@ impl From<BigUint> for Coins {
     }
 }
 
-impl Into<BigUint> for Coins {
-    fn into(self) -> BigUint {
-        self.0
+impl From<Coins> for BigUint {
+    fn from(coins: Coins) -> Self {
+        coins.0
     }
 }
 

--- a/src/types/int.rs
+++ b/src/types/int.rs
@@ -15,9 +15,9 @@ impl<const SIZE: usize> From<BigInt> for Int<SIZE> {
     }
 }
 
-impl<const SIZE: usize> Into<BigInt> for Int<SIZE> {
-    fn into(self) -> BigInt {
-        self.0
+impl<const SIZE: usize> From<Int<SIZE>> for BigInt {
+    fn from(value: Int<SIZE>) -> Self {
+        value.0
     }
 }
 

--- a/src/types/uint.rs
+++ b/src/types/uint.rs
@@ -12,9 +12,9 @@ impl<const SIZE: usize> From<BigUint> for Uint<SIZE> {
     }
 }
 
-impl<const SIZE: usize> Into<BigUint> for Uint<SIZE> {
-    fn into(self) -> BigUint {
-        self.0
+impl<const SIZE: usize> From<Uint<SIZE>> for BigUint {
+    fn from(value: Uint<SIZE>) -> Self {
+        value.0
     }
 }
 

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -6,6 +6,6 @@ pub trait CastErrorToAnyhow<R> {
 
 impl<R> CastErrorToAnyhow<R> for Result<R, TonCellError> {
     fn map_err_to_anyhow(self) -> anyhow::Result<R> {
-        self.map_err(|err| anyhow::Error::msg(err))
+        self.map_err(anyhow::Error::msg)
     }
 }


### PR DESCRIPTION
**Summary of changes**:

use From<_> instead of Into<_>
remove redundant closure in map_err
