### PR TITLE
feat: add `From<{int}>` trait for `Coins`, `Int`, `Uint` structs

### DIFF
--- a/src/types/coins.rs
+++ b/src/types/coins.rs
@@ -36,6 +36,21 @@ try_into!(u32);
 try_into!(u64);
 try_into!(u128);
 try_into!(usize);
+macro_rules! impl_from {
+    ($structname: ty) => {
+        impl From<$structname> for Coins {
+            fn from(value: $structname) -> Self {
+                Coins(<BigUint as From<$structname>>::from(value))
+            }
+        }
+    };
+}
+impl_from!(u8);
+impl_from!(u16);
+impl_from!(u32);
+impl_from!(u64);
+impl_from!(u128);
+impl_from!(usize);
 
 impl ToCell for Coins {
     fn store<'a>(&self, builder: &'a mut CellBuilder) -> anyhow::Result<&'a mut CellBuilder> {
@@ -89,6 +104,28 @@ mod tests {
             <Coins as TryInto<usize>>::try_into(Coins(BigUint::from(COINS_VALUE))).unwrap(),
             COINS_VALUE
         );
+
+        assert_eq!(
+            Coins::from(COINS_VALUE as u8),
+            Coins(BigUint::from(COINS_VALUE as u8))
+        );
+        assert_eq!(
+            Coins::from(COINS_VALUE as u16),
+            Coins(BigUint::from(COINS_VALUE as u16))
+        );
+        assert_eq!(
+            Coins::from(COINS_VALUE as u32),
+            Coins(BigUint::from(COINS_VALUE as u32))
+        );
+        assert_eq!(
+            Coins::from(COINS_VALUE as u64),
+            Coins(BigUint::from(COINS_VALUE as u64))
+        );
+        assert_eq!(
+            Coins::from(COINS_VALUE as u128),
+            Coins(BigUint::from(COINS_VALUE as u128))
+        );
+        assert_eq!(Coins::from(COINS_VALUE), Coins(BigUint::from(COINS_VALUE)));
     }
 
     #[test]

--- a/src/types/int.rs
+++ b/src/types/int.rs
@@ -43,6 +43,27 @@ try_into!(i32);
 try_into!(i64);
 try_into!(i128);
 try_into!(isize);
+macro_rules! impl_from {
+    ($structname: ty) => {
+        impl<const SIZE: usize> From<$structname> for Int<SIZE> {
+            fn from(value: $structname) -> Self {
+                Int(<BigInt as From<$structname>>::from(value))
+            }
+        }
+    };
+}
+impl_from!(u8);
+impl_from!(u16);
+impl_from!(u32);
+impl_from!(u64);
+impl_from!(u128);
+impl_from!(usize);
+impl_from!(i8);
+impl_from!(i16);
+impl_from!(i32);
+impl_from!(i64);
+impl_from!(i128);
+impl_from!(isize);
 
 impl<const SIZE: usize> Display for Int<SIZE> {
     fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
@@ -134,6 +155,55 @@ mod tests {
         assert_eq!(
             <Int<BITS> as TryInto<isize>>::try_into(Int(BigInt::from(INT_VALUE))).unwrap(),
             INT_VALUE as isize
+        );
+
+        assert_eq!(
+            Int::<BITS>::from(INT_VALUE as u8),
+            Int::<BITS>(BigInt::from(INT_VALUE as u8))
+        );
+        assert_eq!(
+            Int::<BITS>::from(INT_VALUE as u16),
+            Int::<BITS>(BigInt::from(INT_VALUE as u16))
+        );
+        assert_eq!(
+            Int::<BITS>::from(INT_VALUE as u32),
+            Int::<BITS>(BigInt::from(INT_VALUE as u32))
+        );
+        assert_eq!(
+            Int::<BITS>::from(INT_VALUE as u64),
+            Int::<BITS>(BigInt::from(INT_VALUE as u64))
+        );
+        assert_eq!(
+            Int::<BITS>::from(INT_VALUE as u128),
+            Int::<BITS>(BigInt::from(INT_VALUE as u128))
+        );
+        assert_eq!(
+            Int::<BITS>::from(INT_VALUE),
+            Int::<BITS>(BigInt::from(INT_VALUE))
+        );
+        assert_eq!(
+            Int::<BITS>::from(INT_VALUE as i8),
+            Int::<BITS>(BigInt::from(INT_VALUE as i8))
+        );
+        assert_eq!(
+            Int::<BITS>::from(INT_VALUE as i16),
+            Int::<BITS>(BigInt::from(INT_VALUE as i16))
+        );
+        assert_eq!(
+            Int::<BITS>::from(INT_VALUE as i32),
+            Int::<BITS>(BigInt::from(INT_VALUE as i32))
+        );
+        assert_eq!(
+            Int::<BITS>::from(INT_VALUE as i64),
+            Int::<BITS>(BigInt::from(INT_VALUE as i64))
+        );
+        assert_eq!(
+            Int::<BITS>::from(INT_VALUE as i128),
+            Int::<BITS>(BigInt::from(INT_VALUE as i128))
+        );
+        assert_eq!(
+            Int::<BITS>::from(INT_VALUE as isize),
+            Int::<BITS>(BigInt::from(INT_VALUE as isize))
         );
     }
 

--- a/src/types/uint.rs
+++ b/src/types/uint.rs
@@ -37,6 +37,21 @@ try_into!(u32);
 try_into!(u64);
 try_into!(u128);
 try_into!(usize);
+macro_rules! impl_from {
+    ($structname: ty) => {
+        impl<const SIZE: usize> From<$structname> for Uint<SIZE> {
+            fn from(value: $structname) -> Self {
+                Uint(<BigUint as From<$structname>>::from(value))
+            }
+        }
+    };
+}
+impl_from!(u8);
+impl_from!(u16);
+impl_from!(u32);
+impl_from!(u64);
+impl_from!(u128);
+impl_from!(usize);
 
 impl<const SIZE: usize> Display for Uint<SIZE> {
     fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
@@ -108,6 +123,31 @@ mod tests {
         assert_eq!(
             <Uint<BITS> as TryInto<usize>>::try_into(Uint(BigUint::from(INT_VALUE))).unwrap(),
             INT_VALUE
+        );
+
+        assert_eq!(
+            Uint::<BITS>::from(INT_VALUE as u8),
+            Uint::<BITS>(BigUint::from(INT_VALUE as u8))
+        );
+        assert_eq!(
+            Uint::<BITS>::from(INT_VALUE as u16),
+            Uint::<BITS>(BigUint::from(INT_VALUE as u16))
+        );
+        assert_eq!(
+            Uint::<BITS>::from(INT_VALUE as u32),
+            Uint::<BITS>(BigUint::from(INT_VALUE as u32))
+        );
+        assert_eq!(
+            Uint::<BITS>::from(INT_VALUE as u64),
+            Uint::<BITS>(BigUint::from(INT_VALUE as u64))
+        );
+        assert_eq!(
+            Uint::<BITS>::from(INT_VALUE as u128),
+            Uint::<BITS>(BigUint::from(INT_VALUE as u128))
+        );
+        assert_eq!(
+            Uint::<BITS>::from(INT_VALUE),
+            Uint::<BITS>(BigUint::from(INT_VALUE))
         );
     }
 


### PR DESCRIPTION
**Summary of changes**:

Implemented more `From<_>` trait for `Coins`, `Int`, `Uint` structs. It allows to use the following construction `Int::from(100500_u32)` instead of `Int::from(BigInt::from(100500_u32))`.